### PR TITLE
Add ROM path CLI arg and quit handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod cpu;
 mod interconnect;
 mod ppu;
 
-use std::io::Result;
+use std::{env, io::Result};
 //use sdl2::event::Event;
 //use sdl2::keyboard::Keycode;
 
@@ -13,9 +13,10 @@ use crate::cart::Cart;
 //use crate::ppu::{Ppu, init_sdl};
 
 fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
     let mut cart = cart::Cart::new();
 
-    cart.filename = "/home/shanesopel/rust/FerrisBoy/roms/dmg-acid2.gb".to_string();
+    cart.filename = args[1].clone();
     cart.cart_load()?;
 
     let inter = interconnect::Interconnect::new(cart.rom_data);
@@ -52,7 +53,7 @@ fn main() -> Result<()> {
 
     let mut last_cpu_cycles = cpu.cycles;
 
-    loop {
+    'outer: loop {
         for event in event_pump.poll_iter() {
             use sdl2::event::Event;
             use sdl2::keyboard::Keycode;
@@ -64,7 +65,7 @@ fn main() -> Result<()> {
                         ..
                     }
             ) {
-                break;
+                break 'outer;
             }
         }
 
@@ -81,4 +82,6 @@ fn main() -> Result<()> {
         // Draw framebuffer
         ppu.draw(&mut canvas);
     }
+
+    Ok(())
 }


### PR DESCRIPTION
Hi. I added two small fixes that might be useful and should improve the UX:

- Added `argv` parsing to allow setting the ROM path via CLI argument
- Inner `break` exits the outer loop now, it should improve the application shutdown

If this isn't needed or you would like it done differently let me know